### PR TITLE
bsp: add intenral bsp path

### DIFF
--- a/Kbuild.mk
+++ b/Kbuild.mk
@@ -47,3 +47,9 @@ subdir-cflags-y += -I$(T)/bsp/include
 -include packages/*/package.mk
 -include packages/*/*/package.mk
 -include packages/*/*/*/package.mk
+
+# Optional internal BSP path
+ifdef INTERNAL_BSP_PATH
+obj-y += $(INTERNAL_BSP_PATH)/
+subdir-cflags-y += -I$(INTERNAL_BSP_PATH)/include
+endif

--- a/Kconfig
+++ b/Kconfig
@@ -65,3 +65,9 @@ config GPIO_DRIVER_TESTS
 	bool "GPIO driver tests"
 
 endmenu
+
+config INTERNAL_BSP_PATH
+    string
+    option env="INTERNAL_BSP_PATH"
+
+-source "$INTERNAL_BSP_PATH/Kconfig"

--- a/build/common_targets.mk
+++ b/build/common_targets.mk
@@ -48,6 +48,7 @@ endif
 
 export OUT
 export PROJECT_PATH
+export INTERNAL_BSP_PATH
 
 pub:
 	$(AT)mkdir -p $(PUB)

--- a/build/project.mk
+++ b/build/project.mk
@@ -148,6 +148,7 @@ endif
 # when other make goals are invoked
 SETUP_VARS += \
     PROJECT_PATH              \
+    INTERNAL_BSP_PATH         \
     PROJECT                   \
     BOARD                     \
     BUILDVARIANT              \


### PR DESCRIPTION
Added internal bsp path variable INTERNAL_BSP_PATH,
a specific internal bsp path can be defined by the command:

    override INTERNAL_BSP_PATH := <internal_bsp_path>

somewhere in a Makefile.

Signed-off-by: Jun Li <jun.r.li@intel.com>